### PR TITLE
Update command substitution notation and add some extended info options

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -252,7 +252,8 @@ prompt_time() {
 prompt_status() {
   local symbols
   symbols=()
-  [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}✘"
+  [[ $RETVAL -ne 0 && $BULLETTRAIN_EXIT_SHOW != true ]] && symbols+="%{%F{red}%}✘ "
+  [[ $RETVAL -ne 0 && $BULLETTRAIN_EXIT_SHOW == true ]] && symbols+="%{%F{red}%}✘ $RETVAL"
   [[ $UID -eq 0 ]] && symbols+="%{%F{yellow}%}⚡"
   [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}⚙"
 


### PR DESCRIPTION
Just a few quick tweaks, one to update all older `` notation to $() style, and a couple to add new options for extended prompt info (e.g. exit code, extra git status, extended directory/path)
