### PR TITLE
Add some user selectable prompt character options

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -263,6 +263,23 @@ prompt_status() {
   [[ -n "$symbols" ]] && prompt_segment $BULLETTRAIN_STATUS_BG $BULLETTRAIN_STATUS_FG "$symbols"
 }
 
+# Prompt Character:
+#   should we show a basic '$' char
+#   or colored (red/green) different
+#   chars for root/normal prompt?
+prompt_char() {
+  local bt_prompt_char
+  if [[ ${#BULLETTRAIN_PROMPT_CHAR} -eq 1 ]] then
+    bt_prompt_char="${BULLETTRAIN_PROMPT_CHAR}"
+  else
+    bt_prompt_char="\$"
+  fi
+  if [[ $BULLETTRAIN_PROMPT_ROOT == true ]] then
+    bt_prompt_char="%(!.%F{red}#.%F{green}${bt_prompt_char})"
+  fi
+  echo -n $bt_prompt_char
+}
+
 # ------------------------------------------------------------------------------
 # MAIN
 # Entry point
@@ -284,4 +301,4 @@ build_prompt() {
 
 PROMPT='
 %{%f%b%k%}$(build_prompt)
-%{${fg_bold[default]}%}\$ %{$reset_color%}'
+%{${fg_bold[default]}%}$(prompt_char) %{$reset_color%}'


### PR DESCRIPTION
This adds 2 new options:

'BULLETTRAIN_PROMPT_ROOT' - changes the default '$' prompt to an alternating '#' for root user and '$' for every other user.
BULLETTRAIN_PROMPT_CHAR - allows the user to specify a single character (e.g. '❯') to override the default '$' as their prompt character of choice. This is ignored if the length of the var/setting is greater than 1.

This also has the beginning of color changing options (e.g. red '#' for root, green '$' for normal users?) and could be expanded in the future for user settable color choices.
