### PR TITLE
Fix bug/typo in time segment

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -244,7 +244,7 @@ prompt_time() {
     return
   fi
 
-  if [[ $BULLETTRAIN_TIME_BG == '' && $BULLETTRAIN_TIME_BG == '' ]] then
+  if [[ $BULLETTRAIN_TIME_BG == '' && $BULLETTRAIN_TIME_FG == '' ]] then
     prompt_standout_segment %D{%H:%M:%S}
   else
     prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%H:%M:%S}


### PR DESCRIPTION
Fix to ensure that we check the state of both 'BULLETTRAIN_TIME_BG' and 'BULLETTRAIN_TIME_FG', instead of checking just BG twice.
