### PR TITLE
Add install instructions for antigen users

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ In order to use the theme, you will first need:
 
 ## Installing
 
+### For oh-my-zsh users
 1. Download the theme [here](http://raw.github.com/caiogondim/bullet-train-oh-my-zsh-theme/master/bullet-train.zsh-theme)
 
 2. Put the file **bullet-train.zsh-theme** in **~/.oh-my-zsh/themes/**
@@ -65,6 +66,13 @@ In order to use the theme, you will first need:
 ```bash
 ZSH_THEME="bullet-train"
 ```
+
+### For antigen users
+add
+```bash
+antigen theme https://github.com/caiogondim/bullet-train-oh-my-zsh-theme bullet-train
+```
+to your .zshrc somewhere after the line ```antigen use oh-my-zsh```
 
 
 ## Options


### PR DESCRIPTION
I use bullet-train with antigen instead of oh-my-zsh, adding instructions.
