### PR TITLE
Sets status fg to white by default

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -37,7 +37,7 @@ if [ ! -n "${BULLETTRAIN_STATUS_ERROR_BG+1}" ]; then
   BULLETTRAIN_STATUS_ERROR_BG=red
 fi
 if [ ! -n "${BULLETTRAIN_STATUS_FG+1}" ]; then
-  BULLETTRAIN_STATUS_FG=black
+  BULLETTRAIN_STATUS_FG=white
 fi
 
 # TIME


### PR DESCRIPTION
A white status foreground is more readable on my screen on both red and green backgrounds.