### PR TITLE
Fixed highlighting on tab completion (without `zsh-syntax-highlighting`)

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -404,7 +404,7 @@ prompt_char() {
   fi
 
   if [[ $BULLETTRAIN_PROMPT_ROOT == true ]] then
-    bt_prompt_char="%(!.%F{red}#.%F{green}${bt_prompt_char})"
+    bt_prompt_char="%(!.%F{red}#.%F{green}${bt_prompt_char}%f)"
   fi
 
   echo -n $bt_prompt_char


### PR DESCRIPTION
When pressing tab on an incomplete command like `l` or `c` the commandline
turns and stays green so even the output is colored green or the
highlight of the suggestions swaps colors when tabbing through.

This happens only if the `zsh-syntax-highlighting` plugin is not enabled (unlike shown in 
demo `.gif`).

I fixed this by adding the missing `%f` in `prompt_char()`.