### PR TITLE
Add installation with cURL in oh-my-zsh section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,17 @@ ZSH_THEME="bullet-train"
 
 ##### Via cURL
 
-1. Go to Oh My Zsh themes `cd ~/.oh-my-zsh/themes/`
+1. Go to oh-my-zsh themes folder:
 
-2. Download via cURL the theme
+		cd ~/.oh-my-zsh/themes/
 
-		curl -O 'https://raw.githubusercontent.com/caiogondim/bullet-train-oh-my-zsh-theme/master/bullet-train.zsh-theme'
+2. Download the theme via cURL:
+
+		curl -O 'https://raw.githubusercontent.com/caiogondim/bullet-train-oh-my-zsh-theme/master/bullet-train.zsh-theme'```
 
 3. Configure the theme in your **~/.zshrc** file:
 
-```bash
-ZSH_THEME="bullet-train"
-```
+		ZSH_THEME="bullet-train"
 
 
 ### For antigen users

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ In order to use the theme, you will first need:
 
 ### For oh-my-zsh users
 
+##### Manually
+
 1. Download the theme [here](http://raw.github.com/caiogondim/bullet-train-oh-my-zsh-theme/master/bullet-train.zsh-theme)
 
 2. Put the file **bullet-train.zsh-theme** in **~/.oh-my-zsh/themes/**
@@ -75,6 +77,23 @@ In order to use the theme, you will first need:
 ```bash
 ZSH_THEME="bullet-train"
 ```
+
+##### Via cURL
+
+1. Go to Oh My Zsh themes `cd ~/.oh-my-zsh/themes/`
+
+2. Download via cURL the theme
+
+```bash
+curl -O 'https://raw.githubusercontent.com/caiogondim/bullet-train-oh-my-zsh-theme/master/bullet-train.zsh-theme'
+```
+
+3. Configure the theme in your **~/.zshrc** file:
+
+```bash
+ZSH_THEME="bullet-train"
+```
+
 
 ### For antigen users
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ ZSH_THEME="bullet-train"
 
 2. Download via cURL the theme
 
-```bash
-curl -O 'https://raw.githubusercontent.com/caiogondim/bullet-train-oh-my-zsh-theme/master/bullet-train.zsh-theme'
-```
+		curl -O 'https://raw.githubusercontent.com/caiogondim/bullet-train-oh-my-zsh-theme/master/bullet-train.zsh-theme'
 
 3. Configure the theme in your **~/.zshrc** file:
 


### PR DESCRIPTION
Because the download via cURL is more simple. Moreover, is more one alternative.

:smiley: 