### PR TITLE
Testing npm without leting which and type output escape

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -355,7 +355,7 @@ prompt_nvm() {
     return
   fi
 
-  [[ $(which nvm) != "nvm not found" ]] || return
+  [[ $(type nvm >/dev/null 2>&1) || $(which nvm >/dev/null 2>&1) ]] || return
   local nvm_prompt
   nvm_prompt=$(node -v 2>/dev/null)
   [[ "${nvm_prompt}x" == "x" ]] && return


### PR DESCRIPTION
This fix issue #38 