### PR TITLE
Add quotes ?

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -369,7 +369,7 @@ prompt_time() {
     return
   fi
 
-  prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%H:%M:%S}
+  prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG '%D{%H:%M:%S}'
 }
 
 # Status:

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -369,7 +369,7 @@ prompt_time() {
     return
   fi
 
-  prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG '%D{%H:%M:%S}'
+  prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG '%D{%d/%m/%Y %H:%M:%S}'
 }
 
 # Status:


### PR DESCRIPTION
in a fr_FR.UTF-8 environment, time shown was the date in EN format (y-m-d).
With quotes, i got %h:%m%s, as expected