### PR TITLE
Added quotes in time format

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -369,7 +369,7 @@ prompt_time() {
     return
   fi
 
-  prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%H:%M:%S}
+  prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG '%D{%H:%M:%S}'
 }
 
 # Status:


### PR DESCRIPTION
In a fr_FR.UTF-8 environment, i only got date in english format instead of default time format of the theme.
Adding quotes solves the problem, time format is shown as expected.