### PR TITLE
Add support for displaying time in 12-hour format

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ or don't want to see. All options must be overridden in your **.zshrc** file.
 |Variable|Default|Meaning
 |--------|-------|-------|
 |`BULLETTRAIN_TIME_SHOW`|`true`|Show/hide that segment
+|`BULLETTRAIN_TIME_12HR`|`false`|Format time using 12-hour clock (am/pm)
 |`BULLETTRAIN_TIME_BG`|`''`|Background color
 |`BULLETTRAIN_TIME_FG`|`''`|Foreground color
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -371,7 +371,7 @@ prompt_time() {
   if [[ $BULLETTRAIN_TIME_12HR == true ]] then
     prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%r}
   else
-    prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%R}
+    prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%X}
   fi
 }
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -368,7 +368,11 @@ prompt_time() {
     return
   fi
 
-  prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%H:%M:%S}
+  if [[ $BULLETTRAIN_TIME_12HR == true ]] then
+    prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%r}
+  else
+    prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%R}
+  fi
 }
 
 # Status:


### PR DESCRIPTION
- Introduces a flag, `$BULLETTRAIN_TIME_12HR`, indicating if 12-hour format should be used
- Default to 24 hour time
- Document new option in README

Refs issue #52