### PR TITLE
Make shortening of the current working directory in prompt configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ or don't want to see. All options must be overridden in your **.zshrc** file.
 |`BULLETTRAIN_DIR_BG`|`blue`|Background color
 |`BULLETTRAIN_DIR_FG`|`white`|Foreground color
 |`BULLETTRAIN_DIR_CONTEXT_SHOW`|`false`|Show user and machine in an SCP formatted style
-|`BULLETTRAIN_DIR_EXTENDED`|`true`|Extended path
+|`BULLETTRAIN_DIR_EXTENDED`|`1`|Extended path (0=short path, 1=medium path, 2=complete path, everything else=medium path)
 
 ### Git
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -109,6 +109,9 @@ fi
 if [ ! -n "${BULLETTRAIN_DIR_EXTENDED+1}" ]; then
   BULLETTRAIN_DIR_EXTENDED=true
 fi
+if [ ! -n "${BULLETTRAIN_DIR_DONTSHORTEN+1}" ]; then
+  BULLETTRAIN_DIR_DONTSHORTEN=false
+fi
 
 # GIT
 if [ ! -n "${BULLETTRAIN_GIT_SHOW+1}" ]; then
@@ -319,7 +322,17 @@ prompt_dir() {
   local dir=''
   local _context="$(context)"
   [[ $BULLETTRAIN_DIR_CONTEXT_SHOW == true && -n "$_context" ]] && dir="${dir}${_context}:"
-  [[ $BULLETTRAIN_DIR_EXTENDED == true ]] && dir="${dir}%4(c:...:)%3c" || dir="${dir}%1~"
+
+  if [[ $BULLETTRAIN_DIR_EXTENDED == true ]] then
+    if [[ $BULLETTRAIN_DIR_DONTSHORTEN == true ]] then
+      dir="${dir}%0~"
+    else
+      dir="${dir}%4(c:...:)%3c"
+    fi
+  else
+    dir="${dir}%1~"
+  fi
+
   prompt_segment $BULLETTRAIN_DIR_BG $BULLETTRAIN_DIR_FG $dir
 }
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -27,9 +27,9 @@ fi
 if [ ! -n "${BULLETTRAIN_STATUS_SHOW+1}" ]; then
   BULLETTRAIN_STATUS_SHOW=true
 fi
-if [ ! -n "${BULLETTRAIN_STATUS_EXIT_SHOW+1}" ]; then
-  BULLETTRAIN_STATUS_EXIT_SHOW=false
-fi
+  if [ ! -n "${BULLETTRAIN_STATUS_EXIT_SHOW+1}" ]; then
+    BULLETTRAIN_STATUS_EXIT_SHOW=false
+  fi
 if [ ! -n "${BULLETTRAIN_STATUS_BG+1}" ]; then
   BULLETTRAIN_STATUS_BG=green
 fi
@@ -107,10 +107,7 @@ if [ ! -n "${BULLETTRAIN_DIR_CONTEXT_SHOW+1}" ]; then
   BULLETTRAIN_DIR_CONTEXT_SHOW=false
 fi
 if [ ! -n "${BULLETTRAIN_DIR_EXTENDED+1}" ]; then
-  BULLETTRAIN_DIR_EXTENDED=true
-fi
-if [ ! -n "${BULLETTRAIN_DIR_DONTSHORTEN+1}" ]; then
-  BULLETTRAIN_DIR_DONTSHORTEN=false
+  BULLETTRAIN_DIR_EXTENDED=1
 fi
 
 # GIT
@@ -323,14 +320,15 @@ prompt_dir() {
   local _context="$(context)"
   [[ $BULLETTRAIN_DIR_CONTEXT_SHOW == true && -n "$_context" ]] && dir="${dir}${_context}:"
 
-  if [[ $BULLETTRAIN_DIR_EXTENDED == true ]] then
-    if [[ $BULLETTRAIN_DIR_DONTSHORTEN == true ]] then
-      dir="${dir}%0~"
-    else
-      dir="${dir}%4(c:...:)%3c"
-    fi
-  else
+  if [[ $BULLETTRAIN_DIR_EXTENDED == 0 ]]; then
+    #short directories
     dir="${dir}%1~"
+  elif [[ $BULLETTRAIN_DIR_EXTENDED == 2 ]]; then
+    #long directories
+    dir="${dir}%0~"
+  else
+    #medium directories (default case)
+    dir="${dir}%4(c:...:)%3c"
   fi
 
   prompt_segment $BULLETTRAIN_DIR_BG $BULLETTRAIN_DIR_FG $dir


### PR DESCRIPTION
This patch makes the shortening of the current working directory in the prompt configurable via the BULLETTRAIN_DIR_DONTSHORTEN environment variable.
If this variable is set to true in combination with BULLETTRAIN_DIR_EXTENDED, the full path of the current working directory is displayed. If you are in a subdirectory relative to $HOME, the first part is replaced with ~