### PR TITLE
Add support for three display modes of the path in the prompt: short, medium and long

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ or don't want to see. All options must be overridden in your **.zshrc** file.
 |`BULLETTRAIN_DIR_BG`|`blue`|Background color
 |`BULLETTRAIN_DIR_FG`|`white`|Foreground color
 |`BULLETTRAIN_DIR_CONTEXT_SHOW`|`false`|Show user and machine in an SCP formatted style
-|`BULLETTRAIN_DIR_EXTENDED`|`true`|Extended path
+|`BULLETTRAIN_DIR_EXTENDED`|`1`|Extended path (0=short path, 1=medium path, 2=complete path, everything else=medium path)
 
 ### Git
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -107,7 +107,7 @@ if [ ! -n "${BULLETTRAIN_DIR_CONTEXT_SHOW+1}" ]; then
   BULLETTRAIN_DIR_CONTEXT_SHOW=false
 fi
 if [ ! -n "${BULLETTRAIN_DIR_EXTENDED+1}" ]; then
-  BULLETTRAIN_DIR_EXTENDED=true
+  BULLETTRAIN_DIR_EXTENDED=1
 fi
 
 # GIT
@@ -319,7 +319,18 @@ prompt_dir() {
   local dir=''
   local _context="$(context)"
   [[ $BULLETTRAIN_DIR_CONTEXT_SHOW == true && -n "$_context" ]] && dir="${dir}${_context}:"
-  [[ $BULLETTRAIN_DIR_EXTENDED == true ]] && dir="${dir}%4(c:...:)%3c" || dir="${dir}%1~"
+
+  if [[ $BULLETTRAIN_DIR_EXTENDED == 0 ]]; then
+    #short directories
+    dir="${dir}%1~"
+  elif [[ $BULLETTRAIN_DIR_EXTENDED == 2 ]]; then
+    #long directories
+    dir="${dir}%0~"
+  else
+    #medium directories (default case)
+    dir="${dir}%4(c:...:)%3c"
+  fi
+
   prompt_segment $BULLETTRAIN_DIR_BG $BULLETTRAIN_DIR_FG $dir
 }
 


### PR DESCRIPTION
This patch adds support for three display modes of the path in the prompt via the BULLETTRAIN_DIR_EXTENDED variable:

* `0`: short path - just the current directory name
* `1`: medium path - the current directory path with up to three elements after which the path gets short with an ellipsis (default)
* `2`: long path - the full path is shown, `$HOME` is abbreviated with `~`

Also see pull-request https://github.com/caiogondim/bullet-train-oh-my-zsh-theme/pull/54 for reference where I screwed up a little ;)