### PR TITLE
Fix unmatched quote

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -435,7 +435,7 @@ prompt_char() {
   fi
 
   if [[ $BULLETTRAIN_PROMPT_SEPARATE_LINE == false  ]]; then
-    bt_prompt_char=" ${bt_prompt_char}
+    bt_prompt_char="${bt_prompt_char}"
   fi
 
   echo -n $bt_prompt_char


### PR DESCRIPTION
Hey, an unmatched quote was causing an error on startup:

```bash
if [[ $BULLETTRAIN_PROMPT_SEPARATE_LINE == false  ]]; then
    bt_prompt_char=" ${bt_prompt_char}
  fi
```

to:

```bash
if [[ $BULLETTRAIN_PROMPT_SEPARATE_LINE == false  ]]; then
    bt_prompt_char="${bt_prompt_char}"
  fi
```

so I fixed it. I'm not very well versed in bash, but it did the trick for me. Any problems let me know. 

Thanks, 
Nick.