### PR TITLE
I took a look at this answer http://unix.stackexchange.com/a/90876

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -473,7 +473,7 @@ prompt_char() {
 prompt_line_sep() {
   if [[ $BULLETTRAIN_PROMPT_SEPARATE_LINE == true ]]; then
     # newline wont print without a non newline character, so add a zero-width space
-    echo -e '\n\u200B'
+    echo -e '\n%{\u200B%}'
   fi
 }
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
and thus added the %{%}-delimiters around the `prompt_line_sep` whitespace.
Works for me and fixes #80