### PR TITLE
Move path before dev-specific segments; dev segments closer to git

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -490,12 +490,12 @@ build_prompt() {
   RETVAL=$?
   prompt_time
   prompt_status
+  prompt_context
+  prompt_dir
   prompt_ruby
   prompt_virtualenv
   prompt_nvm
   prompt_go
-  prompt_context
-  prompt_dir
   prompt_git
   # prompt_hg
   prompt_end


### PR DESCRIPTION
Feel free to close but I think the prompt is more user-friendly when the CWD is in a predictable location. This change will also move the dev-specific segments (ruby/virtualenv/nvm/go) closer to the git segment. What do you think?