### PR TITLE
Update $BULLETTRAIN_TIME_12HR

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -426,7 +426,7 @@ prompt_time() {
   if [[ $BULLETTRAIN_TIME_12HR == true ]]; then
     prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%r}
   else
-    prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%X}
+    prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%T}
   fi
 }
 


### PR DESCRIPTION
change the ```%X``` in ```prompt_time()``` to ```%T```, because ```%X``` is based on local time so even if  ```$BULLETTRAIN_TIME_12HR``` is false, the time would be in 12hr format because of the local.
The ```%T``` forces it in 24hr format  whatever your zone is.