### PR TITLE
Fix chruby support by only printing the line of the matched ruby

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -378,7 +378,7 @@ prompt_ruby() {
       prompt_segment $BULLETTRAIN_RUBY_BG $BULLETTRAIN_RUBY_FG $BULLETTRAIN_RUBY_PREFIX" $(rvm-prompt i v g)"
     fi
   elif command -v chruby > /dev/null 2>&1; then
-    prompt_segment $BULLETTRAIN_RUBY_BG $BULLETTRAIN_RUBY_FG $BULLETTRAIN_RUBY_PREFIX"  $(chruby | sed -e 's/ \* //')"
+    prompt_segment $BULLETTRAIN_RUBY_BG $BULLETTRAIN_RUBY_FG $BULLETTRAIN_RUBY_PREFIX"  $(chruby | sed -n -e 's/ \* //p')"
   elif command -v rbenv > /dev/null 2>&1; then
     prompt_segment $BULLETTRAIN_RUBY_BG $BULLETTRAIN_RUBY_FG $BULLETTRAIN_RUBY_PREFIX" $(rbenv version | sed -e 's/ (set.*$//')"
   fi


### PR DESCRIPTION
This PR fixes a chruby output bug. Currently, it looks like this:

https://s3.amazonaws.com/f.cl.ly/items/1O390u2W0j3j1O2x2q05/Screen%20Shot%202015-11-22%20at%2011.45.27%20PM.png

If you have say 3 rubies installed, the sed command only replaces the ` * ` prefix on the selected chruby version, but doesn't strip out the other rubies installed. This PR only prints the matching line with an active ruby.