### PR TITLE
add BULLETTRAIN_GIT_COLORIZE_DIRTY to show yellow BG when in dirty state

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ or don't want to see. All options must be overridden in your **.zshrc** file.
 |Variable|Default|Meaning
 |--------|-------|-------|
 |`BULLETTRAIN_GIT_SHOW`|`true`|Show/hide that segment
+|`BULLETTRAIN_GIT_COLORIZE_DIRTY`|`false`|Set BULLETTRAIN_GIT_BG to yellow in dirty state
 |`BULLETTRAIN_GIT_BG`|`white`|Background color
 |`BULLETTRAIN_GIT_FG`|`black`|Foreground color
 |`BULLETTRAIN_GIT_EXTENDED`|`true`|

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -134,6 +134,9 @@ fi
 if [ ! -n "${BULLETTRAIN_GIT_SHOW+1}" ]; then
   BULLETTRAIN_GIT_SHOW=true
 fi
+if [ ! -n "${BULLETTRAIN_GIT_COLORIZE_DIRTY+1}" ]; then
+  BULLETTRAIN_GIT_COLORIZE_DIRTY=false
+fi
 if [ ! -n "${BULLETTRAIN_GIT_BG+1}" ]; then
   BULLETTRAIN_GIT_BG=white
 fi
@@ -286,10 +289,16 @@ prompt_git() {
     return
   fi
 
+  is_dirty() {
+    test -n "$(git status --porcelain --ignore-submodules)"
+  }
   local ref dirty mode repo_path
   repo_path=$(git rev-parse --git-dir 2>/dev/null)
 
   if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+    if [[ $BULLETTRAIN_GIT_COLORIZE_DIRTY == true && is_dirty ]]; then
+      BULLETTRAIN_GIT_BG=yellow
+    fi
     prompt_segment $BULLETTRAIN_GIT_BG $BULLETTRAIN_GIT_FG
 
     if [[ $BULLETTRAIN_GIT_EXTENDED == true ]]; then


### PR DESCRIPTION
love bullet-train! but always missing this agnoster feature, so I borrowed some code from [agnoster](https://gist.github.com/agnoster/3712874#file-agnoster-zsh-theme-L82)

when `BULLETTRAIN_GIT_COLORIZE_DIRTY==true`
