### PR TITLE
add BULLETTRAIN_GIT_COLORIZE_DIRTY to show yellow BG when in dirty state

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ or don't want to see. All options must be overridden in your **.zshrc** file.
 |Variable|Default|Meaning
 |--------|-------|-------|
 |`BULLETTRAIN_GIT_SHOW`|`true`|Show/hide that segment
+|`BULLETTRAIN_GIT_COLORIZE_DIRTY`|`false`|Set BULLETTRAIN_GIT_BG to yellow in dirty state
 |`BULLETTRAIN_GIT_BG`|`white`|Background color
 |`BULLETTRAIN_GIT_FG`|`black`|Foreground color
 |`BULLETTRAIN_GIT_EXTENDED`|`true`|

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -134,6 +134,9 @@ fi
 if [ ! -n "${BULLETTRAIN_GIT_SHOW+1}" ]; then
   BULLETTRAIN_GIT_SHOW=true
 fi
+if [ ! -n "${BULLETTRAIN_GIT_COLORIZE_DIRTY+1}" ]; then
+  BULLETTRAIN_GIT_COLORIZE_DIRTY=false
+fi
 if [ ! -n "${BULLETTRAIN_GIT_BG+1}" ]; then
   BULLETTRAIN_GIT_BG=white
 fi
@@ -290,6 +293,9 @@ prompt_git() {
   repo_path=$(git rev-parse --git-dir 2>/dev/null)
 
   if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+    if [[ $BULLETTRAIN_GIT_COLORIZE_DIRTY == true && $(git status --porcelain --ignore-submodules) ]]; then
+      BULLETTRAIN_GIT_BG=yellow
+    fi
     prompt_segment $BULLETTRAIN_GIT_BG $BULLETTRAIN_GIT_FG
 
     if [[ $BULLETTRAIN_GIT_EXTENDED == true ]]; then


### PR DESCRIPTION
display a yellow background color to visualize git repo dirty state is useful, I know there's this `✘` symbol that does the same thing, but sometimes there can be too many symbols around and one can miss the cross, and push their code by mistake.

I think with this feature introduced (borrowed), one can better work with `git push` because it's more visual significance when it's OK to push.

![timfeirg_timfeirg-mba-2____tacitus](https://cloud.githubusercontent.com/assets/4319104/11461588/0add16d8-9741-11e5-83c9-9c5e1a11f100.gif)

## this code is borrowed from agnoster

https://gist.github.com/agnoster/3712874#file-agnoster-zsh-theme-L82