### PR TITLE
Allow replacing git prompt string

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -160,6 +160,12 @@ fi
 if [ ! -n "${BULLETTRAIN_GIT_EXTENDED+1}" ]; then
   BULLETTRAIN_GIT_EXTENDED=true
 fi
+if [ ! -n "${BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_FROM+1}" ]; then
+  BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_FROM=""
+fi
+if [ ! -n "${BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_TO+1}" ]; then
+  BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_TO=""
+fi
 
 # HG
 if [ ! -n "${BULLETTRAIN_HG_SHOW+1}" ]; then
@@ -343,7 +349,7 @@ prompt_git() {
     return
   fi
 
-  local ref dirty mode repo_path
+  local ref dirty mode repo_path substituted_prompt
   repo_path=$(git rev-parse --git-dir 2>/dev/null)
 
   if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
@@ -352,10 +358,12 @@ prompt_git() {
     fi
     prompt_segment $BULLETTRAIN_GIT_BG $BULLETTRAIN_GIT_FG
 
+    substituted_prompt=${$(git_prompt_info)//${BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_FROM}/${BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_TO}}
+
     if [[ $BULLETTRAIN_GIT_EXTENDED == true ]]; then
-      echo -n $(git_prompt_info)$(git_prompt_status)
+      echo -n ${substituted_prompt}$(git_prompt_status)
     else
-      echo -n $(git_prompt_info)
+      echo -n ${substituted_prompt}
     fi
   fi
 }

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -160,11 +160,8 @@ fi
 if [ ! -n "${BULLETTRAIN_GIT_EXTENDED+1}" ]; then
   BULLETTRAIN_GIT_EXTENDED=true
 fi
-if [ ! -n "${BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_FROM+1}" ]; then
-  BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_FROM=""
-fi
-if [ ! -n "${BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_TO+1}" ]; then
-  BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_TO=""
+if [ ! -n "${BULLETTRAIN_GIT_PROMPT_CMD+1}" ]; then
+  BULLETTRAIN_GIT_PROMPT_CMD="\$(git_prompt_info)"
 fi
 
 # HG
@@ -349,7 +346,7 @@ prompt_git() {
     return
   fi
 
-  local ref dirty mode repo_path substituted_prompt
+  local ref dirty mode repo_path git_prompt
   repo_path=$(git rev-parse --git-dir 2>/dev/null)
 
   if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
@@ -358,12 +355,11 @@ prompt_git() {
     fi
     prompt_segment $BULLETTRAIN_GIT_BG $BULLETTRAIN_GIT_FG
 
-    substituted_prompt=${$(git_prompt_info)//${BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_FROM}/${BULLETTRAIN_GIT_PROMPT_SUBSTITUTION_TO}}
-
+    eval git_prompt=${BULLETTRAIN_GIT_PROMPT_CMD}
     if [[ $BULLETTRAIN_GIT_EXTENDED == true ]]; then
-      echo -n ${substituted_prompt}$(git_prompt_status)
+      echo -n ${git_prompt}$(git_prompt_status)
     else
-      echo -n ${substituted_prompt}
+      echo -n ${git_prompt}
     fi
   fi
 }


### PR DESCRIPTION
Use build-in functionality to substitute substring with another one.

This was in my local changes for some time. I am using git flow with default feature prefix "feature/". This does not look good with bullet-train prompt. So, this feature gives us ability to change:

![before](https://cloud.githubusercontent.com/assets/11866902/12537502/320a83ac-c2c1-11e5-894c-8416138a93e8.png)

to:

![after](https://cloud.githubusercontent.com/assets/11866902/12537503/3589b746-c2c1-11e5-904b-24be3444ecfd.png)

Which is more bullet-train-like IMHO.

What do you think?