### PR TITLE
Allow settings custom git prompt

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -160,6 +160,9 @@ fi
 if [ ! -n "${BULLETTRAIN_GIT_EXTENDED+1}" ]; then
   BULLETTRAIN_GIT_EXTENDED=true
 fi
+if [ ! -n "${BULLETTRAIN_GIT_PROMPT_CMD+1}" ]; then
+  BULLETTRAIN_GIT_PROMPT_CMD="\$(git_prompt_info)"
+fi
 
 # HG
 if [ ! -n "${BULLETTRAIN_HG_SHOW+1}" ]; then
@@ -343,7 +346,7 @@ prompt_git() {
     return
   fi
 
-  local ref dirty mode repo_path
+  local ref dirty mode repo_path git_prompt
   repo_path=$(git rev-parse --git-dir 2>/dev/null)
 
   if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
@@ -352,10 +355,11 @@ prompt_git() {
     fi
     prompt_segment $BULLETTRAIN_GIT_BG $BULLETTRAIN_GIT_FG
 
+    eval git_prompt=${BULLETTRAIN_GIT_PROMPT_CMD}
     if [[ $BULLETTRAIN_GIT_EXTENDED == true ]]; then
-      echo -n $(git_prompt_info)$(git_prompt_status)
+      echo -n ${git_prompt}$(git_prompt_status)
     else
-      echo -n $(git_prompt_info)
+      echo -n ${git_prompt}
     fi
   fi
 }


### PR DESCRIPTION
This gives us ability to use string substitution for changing e.g. how
branch name is displayed.

This was in my local changes for some time. I am using git flow with default feature prefix "feature/". This does not look good with bullet-train prompt. So, this feature gives us ability to change:

![320a83ac-c2c1-11e5-894c-8416138a93e8](https://cloud.githubusercontent.com/assets/11866902/12593561/fadc07a4-c471-11e5-90cd-cb43732390aa.png)

to:

![3589b746-c2c1-11e5-904b-24be3444ecfd](https://cloud.githubusercontent.com/assets/11866902/12593574/09d2b0dc-c472-11e5-9311-9ec6ec8c7adc.png)

----

This implementation allows user to specify git prompt command. By default we set it to ```git_prompt_info```. As this isn't the actual execution of command, we need to delay variable/function extending, thus ``\${git_prompt_info}``.

So, in case showed on screens this would be 
``` bash
BULLETTRAIN_GIT_PROMPT_CMD=\${\$(git_prompt_info)//\\//\ \ }
```

Please note, that we still need to *delay* variable expansion, so we need to escape all *weird* character - **$**, **\**, **\<space>**, etc.

----

This is second pull request - I am still learning github and I messed something in previous. 

Thanks to @dbkaplun for idea how to give user full flexibility for this.