### PR TITLE
Feature right prompt

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -282,7 +282,7 @@ fi
 
 # USER
 if [ ! -n "${BULLETTRAIN_USER_SHOW+1}" ]; then
-  BULLETTRAIN_USER_SHOW=false
+  BULLETTRAIN_USER_SHOW=true
 fi
 if [ ! -n "${BULLETTRAIN_USER_BG+1}" ]; then
   BULLETTRAIN_USER_BG=green
@@ -293,7 +293,7 @@ fi
 
 # HOST
 if [ ! -n "${BULLETTRAIN_HOST_SHOW+1}" ]; then
-  BULLETTRAIN_HOST_SHOW=false
+  BULLETTRAIN_HOST_SHOW=true
 fi
 if [ ! -n "${BULLETTRAIN_HOST_BG+1}" ]; then
   BULLETTRAIN_HOST_BG=black
@@ -323,8 +323,10 @@ prompt_segment() {
       echo -n " %{$bg%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR%{$fg%} "
     else
       echo -n "%{$bg%}%{$fg%} "
-  if [[ $SEGMENT_PLACE == 'RIGHT' ]]; then
-      echo -n " %{$fg%K{$CURRENT_BG}%}$SEGMENT_SEPARATOR%{$bg%} "
+    fi
+  fi
+  if [[ $SEGMENT_PLACE == 'RIGHT' && -n $1 ]]; then
+      echo -n " %{%F{$1}%K{$CURRENT_BG}%}$SEGMENT_SEPARATOR%{$fg$bg%} "
   fi
   CURRENT_BG=$1
   [[ -n $3 ]] && echo -n $3
@@ -627,7 +629,7 @@ rprompt_user() {
 # Host
 rprompt_host() {
   [[ $BULLETTRAIN_HOST_SHOW == false ]] && return
-  prompt_segment $BULLETTRAIN_USER_BG $BULLETTRAIN_USER_FG "%m"
+  prompt_segment $BULLETTRAIN_HOST_BG $BULLETTRAIN_HOST_FG "%m"
 }
 
 # ------------------------------------------------------------------------------
@@ -664,11 +666,11 @@ PROMPT="$PROMPT"'%{${fg_bold[default]}%}'
 PROMPT="$PROMPT"'$(prompt_char) %{$reset_color%}'
 
 build_rprompt() {
-  CURRENT_BG='NONE
+  CURRENT_BG='NONE'
   SEGMENT_SEPARATOR=''
   SEGMENT_PLACE='RIGHT'
   rprompt_user
   rprompt_host
 }
 
-RPROMPT="$(build_rprompt)'
+RPROMPT='$(build_rprompt)'

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -16,6 +16,8 @@
 VIRTUAL_ENV_DISABLE_PROMPT=true
 
 # PROMPT
+# Note that BULLETTRAIN_PROMPT_SEPARATE_LINE and BULLETTRAIN_PROMPT_ADD_NEWLINE
+# does not work in RPROMPT
 if [ ! -n "${BULLETTRAIN_PROMPT_CHAR+1}" ]; then
   BULLETTRAIN_PROMPT_CHAR="\$"
 fi
@@ -278,7 +280,6 @@ if [ ! -n "${BULLETTRAIN_EXEC_TIME_FG+1}" ]; then
   BULLETTRAIN_EXEC_TIME_FG=black
 fi
 
-
 # ------------------------------------------------------------------------------
 # SEGMENT DRAWING
 # A few functions to make it easy and re-usable to draw segmented prompts
@@ -286,6 +287,7 @@ fi
 
 CURRENT_BG='NONE'
 SEGMENT_SEPARATOR=''
+SEGMENT_PLACE='LEFT'
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,
@@ -294,10 +296,13 @@ prompt_segment() {
   local bg fg
   [[ -n $1 ]] && bg="%K{$1}" || bg="%k"
   [[ -n $2 ]] && fg="%F{$2}" || fg="%f"
-  if [[ $CURRENT_BG != 'NONE' && $1 != $CURRENT_BG ]]; then
-    echo -n " %{$bg%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR%{$fg%} "
-  else
-    echo -n "%{$bg%}%{$fg%} "
+  if [[ $SEGMENT_PLACE == 'LEFT' ]]; then
+    if [[ $CURRENT_BG != 'NONE' && $1 != $CURRENT_BG ]]; then
+      echo -n " %{$bg%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR%{$fg%} "
+    else
+      echo -n "%{$bg%}%{$fg%} "
+  if [[ $SEGMENT_PLACE == 'RIGHT' ]]; then
+      echo -n " %{$fg%K{$CURRENT_BG}%}$SEGMENT_SEPARATOR%{$bg%} "
   fi
   CURRENT_BG=$1
   [[ -n $3 ]] && echo -n $3
@@ -327,7 +332,6 @@ context() {
 }
 prompt_context() {
   [[ $BULLETTRAIN_CONTEXT_SHOW == false ]] && return
-
   local _context="$(context)"
   [[ -n "$_context" ]] && prompt_segment $BULLETTRAIN_CONTEXT_BG $BULLETTRAIN_CONTEXT_FG "$_context"
 }
@@ -586,6 +590,12 @@ prompt_line_sep() {
 }
 
 # ------------------------------------------------------------------------------
+# RPROMPT COMPONENTS
+# Same as PROMPT COMPONENTS except place in RPROMPT, and they are stable while
+# PROMPT COMPONENTS change frequently
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # MAIN
 # Entry point
 # ------------------------------------------------------------------------------
@@ -617,3 +627,11 @@ PROMPT="$PROMPT"'%{%f%b%k%}$(build_prompt)'
 PROMPT="$PROMPT"'%{${fg_bold[default]}%}'
 [[ $BULLETTRAIN_PROMPT_SEPARATE_LINE == false ]] && PROMPT="$PROMPT "
 PROMPT="$PROMPT"'$(prompt_char) %{$reset_color%}'
+
+build_rprompt() {
+  CURRENT_BG='NONE
+  SEGMENT_SEPARATOR=''
+  SEGMENT_PLACE='RIGHT'
+}
+
+RPROMPT="$(build_rprompt)'

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -280,6 +280,17 @@ if [ ! -n "${BULLETTRAIN_EXEC_TIME_FG+1}" ]; then
   BULLETTRAIN_EXEC_TIME_FG=black
 fi
 
+# USER
+if [ ! -n "${BULLETTRAIN_USER_SHOW+1}" ]; then
+  BULLETTRAIN_USER_SHOW=false
+fi
+if [ ! -n "${BULLETTRAIN_USER_BG+1}" ]; then
+  BULLETTRAIN_USER_BG=green
+fi
+if [ ! -n "${BULLETTRAIN_USER_FG+1}" ]; then
+  BULLETTRAIN_USER_FG=white
+fi
+
 # ------------------------------------------------------------------------------
 # SEGMENT DRAWING
 # A few functions to make it easy and re-usable to draw segmented prompts
@@ -595,6 +606,13 @@ prompt_line_sep() {
 # PROMPT COMPONENTS change frequently
 # ------------------------------------------------------------------------------
 
+# User
+rprompt_user() {
+  [[ $BULLETTRAIN_USER_SHOW == false ]] && return
+  local _user="$(whoami)"
+  [[ -n "$_user" ]] && prompt_segment $BULLETTRAIN_USER_BG $BULLETTRAIN_USER_FG "$_user"
+}
+
 # ------------------------------------------------------------------------------
 # MAIN
 # Entry point
@@ -632,6 +650,7 @@ build_rprompt() {
   CURRENT_BG='NONE
   SEGMENT_SEPARATOR=''
   SEGMENT_PLACE='RIGHT'
+  rprompt_user
 }
 
 RPROMPT="$(build_rprompt)'

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -291,6 +291,17 @@ if [ ! -n "${BULLETTRAIN_USER_FG+1}" ]; then
   BULLETTRAIN_USER_FG=white
 fi
 
+# HOST
+if [ ! -n "${BULLETTRAIN_HOST_SHOW+1}" ]; then
+  BULLETTRAIN_HOST_SHOW=false
+fi
+if [ ! -n "${BULLETTRAIN_HOST_BG+1}" ]; then
+  BULLETTRAIN_HOST_BG=black
+fi
+if [ ! -n "${BULLETTRAIN_HOST_FG+1}" ]; then
+  BULLETTRAIN_HOST_FG=white
+fi
+
 # ------------------------------------------------------------------------------
 # SEGMENT DRAWING
 # A few functions to make it easy and re-usable to draw segmented prompts
@@ -613,6 +624,12 @@ rprompt_user() {
   [[ -n "$_user" ]] && prompt_segment $BULLETTRAIN_USER_BG $BULLETTRAIN_USER_FG "$_user"
 }
 
+# Host
+rprompt_host() {
+  [[ $BULLETTRAIN_HOST_SHOW == false ]] && return
+  prompt_segment $BULLETTRAIN_USER_BG $BULLETTRAIN_USER_FG "%m"
+}
+
 # ------------------------------------------------------------------------------
 # MAIN
 # Entry point
@@ -651,6 +668,7 @@ build_rprompt() {
   SEGMENT_SEPARATOR=''
   SEGMENT_PLACE='RIGHT'
   rprompt_user
+  rprompt_host
 }
 
 RPROMPT="$(build_rprompt)'


### PR DESCRIPTION
I add a simple `build_rprompt` function and two rprompt about user and host.

I think `RPROMPT` is suitable to place user and host these **stable** information while the `PROMPT` hold those info which change frequently. So I would advice you to remove the `CONTEXT` components.

Here is the demo.

![1456834180](https://cloud.githubusercontent.com/assets/3921062/13426660/d337b4e4-dfe9-11e5-9d5d-e273908c37c9.png)