### PR TITLE
Eliminating double space if prompt on one line

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -570,8 +570,8 @@ prompt_char() {
     bt_prompt_char="%(!.%F{red}#.%F{green}${bt_prompt_char}%f)"
   fi
 
-  if [[ $BULLETTRAIN_PROMPT_SEPARATE_LINE == false  ]]; then
-    bt_prompt_char=" ${bt_prompt_char}"
+  if [[ $BULLETTRAIN_PROMPT_SEPARATE_LINE == false ]]; then
+    bt_prompt_char="${bt_prompt_char}"
   fi
 
   echo -n $bt_prompt_char


### PR DESCRIPTION
This PR eliminates double space in front of the `$` character at the end of the prompt which appears only if `BULLETTRAIN_PROMPT_SEPARATE_LINE="false"`.