### PR TITLE
close #29: Run shellcheck on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
   - sudo apt-get install shellcheck -y
 
 script:
-  - shellcheck bullet-train.zsh-theme
+  - shellcheck -s-shell=zsh bullet-train.zsh-theme

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
   - sudo apt-get install shellcheck -y
 
 script:
-  - shellcheck -s-shell=zsh bullet-train.zsh-theme
+  - shellcheck -shell=zsh bullet-train.zsh-theme

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
-sudo: false
+sudo: required
 language: node_js
 node_js:
   - 0.10
+
+install:
+  - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ wily universe"
+  - sudo apt-get update -q
+  - sudo apt-get install shellcheck -y
+
+script:
+  - shellcheck bullet-train.zsh-theme

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
   - sudo apt-get install shellcheck -y
 
 script:
-  - shellcheck -shell=zsh bullet-train.zsh-theme
+  - shellcheck --shell=zsh bullet-train.zsh-theme


### PR DESCRIPTION
Even if shellcheck is on travis-ci whitelist it fails to install via
add-ons-apt. The easiest way of installing it is use of apt-get, but
this forces us to drop container-based builds.

See
travis-ci/apt-package-whitelist#376 (comment)
for more details.

This only adds checking on travis, there  is still issue @JonasGroeger mentioned about. Unfortunatelly I am not sure what was the intention of an author @gregf. Unfortunately I also don't know Go... @gregf, can you please explain the `(*qN)` ?