### PR TITLE
Add option for dynamic custom prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ or don't want to see. All options must be overridden in your **.zshrc** file.
 |`BULLETTRAIN_CUSTOM_MSG`|`false`|Free segment you can put a custom message
 |`BULLETTRAIN_CUSTOM_BG`|`black`|Background color
 |`BULLETTRAIN_CUSTOM_FG`|`black`|Foreground color
+|`BULLETTRAIN_CUSTOM_FN`|`''`|Custom function to generate message
 
 ### Context
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -67,6 +67,9 @@ fi
 if [ ! -n "${BULLETTRAIN_CUSTOM_FG+1}" ]; then
   BULLETTRAIN_CUSTOM_FG=default
 fi
+if [ ! -n "${BULLETTRAIN_CUSTOM_FN+1}" ]; then
+    BULLETTRAIN_CUSTOM_FN=
+fi
 
 # VIRTUALENV
 if [ ! -n "${BULLETTRAIN_VIRTUALENV_SHOW+1}" ]; then
@@ -350,11 +353,12 @@ prompt_cmd_exec_time() {
 
 # Custom
 prompt_custom() {
-  if [[ $BULLETTRAIN_CUSTOM_MSG == false ]]; then
-    return
+  if [[ $BULLETTRAIN_CUSTOM_MSG != false ]]; then
+    prompt_segment $BULLETTRAIN_CUSTOM_BG $BULLETTRAIN_CUSTOM_FG "${BULLETTRAIN_CUSTOM_MSG}"
+  elif [[ -n $BULLETTRAIN_CUSTOM_FN ]]; then
+    prompt_segment $BULLETTRAIN_CUSTOM_BG $BULLETTRAIN_CUSTOM_FG $($BULLET_TRAINCUSTOM_FN)
   fi
 
-  prompt_segment $BULLETTRAIN_CUSTOM_BG $BULLETTRAIN_CUSTOM_FG "${BULLETTRAIN_CUSTOM_MSG}"
 }
 
 # Git

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -356,7 +356,10 @@ prompt_custom() {
   if [[ $BULLETTRAIN_CUSTOM_MSG != false ]]; then
     prompt_segment $BULLETTRAIN_CUSTOM_BG $BULLETTRAIN_CUSTOM_FG "${BULLETTRAIN_CUSTOM_MSG}"
   elif [[ -n $BULLETTRAIN_CUSTOM_FN ]]; then
-    prompt_segment $BULLETTRAIN_CUSTOM_BG $BULLETTRAIN_CUSTOM_FG $($BULLET_TRAINCUSTOM_FN)
+    local msg=$($BULLETTRAIN_CUSTOM_FN)
+    if [[ -n $msg ]]; then
+      prompt_segment $BULLETTRAIN_CUSTOM_BG $BULLETTRAIN_CUSTOM_FG "$msg"
+    fi
   fi
 
 }


### PR DESCRIPTION
The custom prompt piece only allowed a static text
via BULLETTRAIN_CUSTOM_MSG. Now another variable is added
called BULLETTRAIN_CUSTOM_FN that should store the name of a custom
function that will be invoked each time the prompt is showed.
E.g. if you define a function my_custom_prompt { ... }
then set BULLETTRAIN_CUSTOM_FN=my_custom_prompt