### PR TITLE
Use node to get version information if nvm is not present. Fixes #132

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ simplicity, showing information only when it's relevant.
 It currently shows:
 - Current Python virtualenv; when using Pyenv and no active virtualenv shows the current Python version the shell uses
 - Current Ruby version using chruby; version and gemset when on RVM or Rbenv
-- Current Node.js version, through NVM
+- Current Node.js version, through NVM (if present) or Node.js
 - Current Perl version using plenv
 - Git status
 - Timestamp

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -539,11 +539,13 @@ prompt_nvm() {
     return
   fi
 
-  $(type nvm >/dev/null 2>&1) || return
-
   local nvm_prompt
-  nvm_prompt=$(nvm current 2>/dev/null)
-  [[ "${nvm_prompt}x" == "x" ]] && return
+  if [[ $(type nvm >/dev/null 2>&1) ]]; then
+    nvm_prompt=$(nvm current 2>/dev/null)
+    [[ "${nvm_prompt}x" == "x" ]] && return
+  else
+    nvm_prompt="$(node --version)"
+  fi
   nvm_prompt=${nvm_prompt}
   prompt_segment $BULLETTRAIN_NVM_BG $BULLETTRAIN_NVM_FG $BULLETTRAIN_NVM_PREFIX$nvm_prompt
 }


### PR DESCRIPTION
Instead of returning if nvm is not present, get version information from node itself.