### PR TITLE
Interpret the signal name when the return value is grater than 128

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 |--------|-------|-------|
 |`BULLETTRAIN_STATUS_SHOW`|`true`|Show/hide that segment
 |`BULLETTRAIN_STATUS_EXIT_SHOW`|`false`|Show/hide exit code of last command
+|`BULLETTRAIN_STATUS_EXIT_SIGNAL_SHOW`|`false`|Enable/disable the signal name interpretation
 |`BULLETTRAIN_STATUS_BG`|`green`|Background color
 |`BULLETTRAIN_STATUS_ERROR_BG`|`red`|Background color of segment when last command exited with an error
 |`BULLETTRAIN_STATUS_FG`|`black`|Foreground color

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -55,6 +55,9 @@ fi
 if [ ! -n "${BULLETTRAIN_STATUS_EXIT_SHOW+1}" ]; then
   BULLETTRAIN_STATUS_EXIT_SHOW=false
 fi
+if [ ! -n "${BULLETTRAIN_STATUS_EXIT_SIGNAL_SHOW+1}" ]; then
+  BULLETTRAIN_STATUS_EXIT_SIGNAL_SHOW=false
+fi
 if [ ! -n "${BULLETTRAIN_STATUS_BG+1}" ]; then
   BULLETTRAIN_STATUS_BG=green
 fi
@@ -591,9 +594,17 @@ prompt_status() {
   fi
 
   local symbols
+  local ret_signal
   symbols=()
+  ret_signal=$(kill -l $(($RETVAL - 128)))
+
   [[ $RETVAL -ne 0 && $BULLETTRAIN_STATUS_EXIT_SHOW != true ]] && symbols+="✘"
-  [[ $RETVAL -ne 0 && $BULLETTRAIN_STATUS_EXIT_SHOW == true ]] && symbols+="✘ $RETVAL"
+  if [[ $RETVAL -gt 128 && $BULLETTRAIN_STATUS_EXIT_SIGNAL_SHOW == true ]]; then
+    # In Linux, return value grater than 128, i.e. 128+n, means fatal error of signal "n"
+    [[ $BULLETTRAIN_STATUS_EXIT_SHOW == true ]] && symbols+="✘ $ret_signal "
+  else
+    [[ $RETVAL -ne 0 && $BULLETTRAIN_STATUS_EXIT_SHOW == true ]] && symbols+="✘ $RETVAL"
+  fi
   [[ $UID -eq 0 ]] && symbols+="%{%F{yellow}%}⚡%f"
   [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="⚙"
 


### PR DESCRIPTION
In Linux Bash-scripting ABI, the return value has its specific meaning
in different range.
Value 128+n means fatal error with signal "n".
For more information, please refer to this link:
http://tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF

You can turn on/off this feature by assigning true/false to this
variable:
BULLETTRAIN_STATUS_EXIT_SIGNAL_SHOW