### PR TITLE
close #186: Remove redundant *_SHOW* variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_STATUS_SHOW`|`true`|Show/hide that segment
 |`BULLETTRAIN_STATUS_EXIT_SHOW`|`false`|Show/hide exit code of last command
 |`BULLETTRAIN_STATUS_BG`|`green`|Background color
 |`BULLETTRAIN_STATUS_ERROR_BG`|`red`|Background color of segment when last command exited with an error
@@ -125,7 +124,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_TIME_SHOW`|`true`|Show/hide that segment
 |`BULLETTRAIN_TIME_12HR`|`false`|Format time using 12-hour clock (am/pm)
 |`BULLETTRAIN_TIME_BG`|`'white'`|Background color
 |`BULLETTRAIN_TIME_FG`|`'black'`|Foreground color
@@ -142,7 +140,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_CONTEXT_SHOW`|`false`|Show/hide that segment
 |`BULLETTRAIN_CONTEXT_BG`|`black`|Background color
 |`BULLETTRAIN_CONTEXT_FG`|`default`|Foreground color
 |`BULLETTRAIN_CONTEXT_DEFAULT_USER`|none|Default user. If you are running with other user other than default, the segment will be showed.
@@ -153,7 +150,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_VIRTUALENV_SHOW`|`true`|Show/hide that segment
 |`BULLETTRAIN_VIRTUALENV_BG`|`yellow`|Background color
 |`BULLETTRAIN_VIRTUALENV_FG`|`white`|Foreground color
 |`BULLETTRAIN_VIRTUALENV_PREFIX`|`🐍`|Prefix of the segment
@@ -162,7 +158,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_NVM_SHOW`|`false`|Show/hide that segment
 |`BULLETTRAIN_NVM_BG`|`green`|Background color
 |`BULLETTRAIN_NVM_FG`|`white`|Foreground color
 |`BULLETTRAIN_NVM_PREFIX`|`"⬡ "`|Prefix of the segment
@@ -171,7 +166,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_RUBY_SHOW`|`true`|Show/hide that segment
 |`BULLETTRAIN_RUBY_BG`|`magenta`|Background color
 |`BULLETTRAIN_RUBY_FG`|`white`|Foreground color
 |`BULLETTRAIN_RUBY_PREFIX`|`"♦"`|Prefix of the segment
@@ -180,7 +174,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_GO_SHOW`|`false`|Show/hide that segment
 |`BULLETTRAIN_GO_BG`|`green`|Background color
 |`BULLETTRAIN_GO_FG`|`white`|Foreground color
 |`BULLETTRAIN_GO_PREFIX`|`go`|Prefix of the segment
@@ -189,7 +182,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_PERL_SHOW`|`false`|Show/hide that segment
 |`BULLETTRAIN_PERL_BG`|`yellow`|Background color
 |`BULLETTRAIN_PERL_FG`|`black`|Foreground color
 |`BULLETTRAIN_PERL_PREFIX`|`🐪`|Prefix of the segment
@@ -198,7 +190,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_DIR_SHOW`|`true`|Show/hide that segment
 |`BULLETTRAIN_DIR_BG`|`blue`|Background color
 |`BULLETTRAIN_DIR_FG`|`white`|Foreground color
 |`BULLETTRAIN_DIR_CONTEXT_SHOW`|`false`|Show user and machine in an SCP formatted style
@@ -208,7 +199,6 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_GIT_SHOW`|`true`|Show/hide that segment
 |`BULLETTRAIN_GIT_COLORIZE_DIRTY`|`false`|Set `BULLETTRAIN_GIT_BG` to `BULLETTRAIN_GIT_COLORIZE_DIRTY_COLOR` in dirty state
 |`BULLETTRAIN_GIT_COLORIZE_DIRTY_BG_COLOR`|`yellow`|`BULLETTRAIN_GIT_BG` in dirty state
 |`BULLETTRAIN_GIT_COLORIZE_DIRTY_FG_COLOR`|`black`|`BULLETTRAIN_GIT_FG` in dirty state
@@ -234,13 +224,11 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_HG_SHOW`|`true`|Show/hide that segment
 
 ### Command execution time
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_EXEC_TIME_SHOW`|`false`|Show/hide that segment
 |`BULLETTRAIN_EXEC_TIME_ELAPSED`|5|Minimum elapsed time of command execution. If the execution time of a command is smaller than this, the segment will be hidden.
 |`BULLETTRAIN_EXEC_TIME_BG`|`yellow`|Background color
 |`BULLETTRAIN_EXEC_TIME_FG`|`black`|Foreground color

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -49,9 +49,6 @@ if [ ! -n "${BULLETTRAIN_PROMPT_ADD_NEWLINE+1}" ]; then
 fi
 
 # STATUS
-if [ ! -n "${BULLETTRAIN_STATUS_SHOW+1}" ]; then
-  BULLETTRAIN_STATUS_SHOW=true
-fi
 if [ ! -n "${BULLETTRAIN_STATUS_EXIT_SHOW+1}" ]; then
   BULLETTRAIN_STATUS_EXIT_SHOW=false
 fi
@@ -66,9 +63,6 @@ if [ ! -n "${BULLETTRAIN_STATUS_FG+1}" ]; then
 fi
 
 # TIME
-if [ ! -n "${BULLETTRAIN_TIME_SHOW+1}" ]; then
-  BULLETTRAIN_TIME_SHOW=true
-fi
 if [ ! -n "${BULLETTRAIN_TIME_BG+1}" ]; then
   BULLETTRAIN_TIME_BG=white
 fi
@@ -88,9 +82,6 @@ if [ ! -n "${BULLETTRAIN_CUSTOM_FG+1}" ]; then
 fi
 
 # VIRTUALENV
-if [ ! -n "${BULLETTRAIN_VIRTUALENV_SHOW+1}" ]; then
-  BULLETTRAIN_VIRTUALENV_SHOW=true
-fi
 if [ ! -n "${BULLETTRAIN_VIRTUALENV_BG+1}" ]; then
   BULLETTRAIN_VIRTUALENV_BG=yellow
 fi
@@ -102,9 +93,6 @@ if [ ! -n "${BULLETTRAIN_VIRTUALENV_PREFIX+1}" ]; then
 fi
 
 # NVM
-if [ ! -n "${BULLETTRAIN_NVM_SHOW+1}" ]; then
-  BULLETTRAIN_NVM_SHOW=false
-fi
 if [ ! -n "${BULLETTRAIN_NVM_BG+1}" ]; then
   BULLETTRAIN_NVM_BG=green
 fi
@@ -116,9 +104,6 @@ if [ ! -n "${BULLETTRAIN_NVM_PREFIX+1}" ]; then
 fi
 
 # RUBY
-if [ ! -n "${BULLETTRAIN_RUBY_SHOW+1}" ]; then
-  BULLETTRAIN_RUBY_SHOW=true
-fi
 if [ ! -n "${BULLETTRAIN_RUBY_BG+1}" ]; then
   BULLETTRAIN_RUBY_BG=magenta
 fi
@@ -130,9 +115,6 @@ if [ ! -n "${BULLETTRAIN_RUBY_PREFIX+1}" ]; then
 fi
 
 # Go
-if [ ! -n "${BULLETTRAIN_GO_SHOW+1}" ]; then
-  BULLETTRAIN_GO_SHOW=false
-fi
 if [ ! -n "${BULLETTRAIN_GO_BG+1}" ]; then
   BULLETTRAIN_GO_BG=cyan
 fi
@@ -144,9 +126,6 @@ if [ ! -n "${BULLETTRAIN_GO_PREFIX+1}" ]; then
 fi
 
 # DIR
-if [ ! -n "${BULLETTRAIN_DIR_SHOW+1}" ]; then
-  BULLETTRAIN_DIR_SHOW=true
-fi
 if [ ! -n "${BULLETTRAIN_DIR_BG+1}" ]; then
   BULLETTRAIN_DIR_BG=blue
 fi
@@ -161,9 +140,6 @@ if [ ! -n "${BULLETTRAIN_DIR_EXTENDED+1}" ]; then
 fi
 
 # GIT
-if [ ! -n "${BULLETTRAIN_GIT_SHOW+1}" ]; then
-  BULLETTRAIN_GIT_SHOW=true
-fi
 if [ ! -n "${BULLETTRAIN_GIT_COLORIZE_DIRTY+1}" ]; then
   BULLETTRAIN_GIT_COLORIZE_DIRTY=false
 fi
@@ -187,9 +163,6 @@ if [ ! -n "${BULLETTRAIN_GIT_PROMPT_CMD+1}" ]; then
 fi
 
 # PERL
-if [ ! -n "${BULLETTRAIN_PERL_SHOW+1}" ]; then
-  BULLETTRAIN_PERL_SHOW=false
-fi
 if [ ! -n "${BULLETTRAIN_PERL_BG+1}" ]; then
   BULLETTRAIN_PERL_BG=yellow
 fi
@@ -200,15 +173,7 @@ if [ ! -n "${BULLETTRAIN_PERL_PREFIX+1}" ]; then
   BULLETTRAIN_PERL_PREFIX=🐪
 fi
 
-# HG
-if [ ! -n "${BULLETTRAIN_HG_SHOW+1}" ]; then
-  BULLETTRAIN_HG_SHOW=true
-fi
-
 # CONTEXT
-if [ ! -n "${BULLETTRAIN_CONTEXT_SHOW+1}" ]; then
-  BULLETTRAIN_CONTEXT_SHOW=false
-fi
 if [ ! -n "${BULLETTRAIN_CONTEXT_BG+1}" ]; then
   BULLETTRAIN_CONTEXT_BG=black
 fi
@@ -287,9 +252,6 @@ else
 fi
 
 # COMMAND EXECUTION TIME
-if [ ! -n "${BULLETTRAIN_EXEC_TIME_SHOW+1}" ]; then
-  BULLETTRAIN_EXEC_TIME_SHOW=false
-fi
 if [ ! -n "${BULLETTRAIN_EXEC_TIME_ELAPSED+1}" ]; then
   BULLETTRAIN_EXEC_TIME_ELAPSED=5
 fi
@@ -347,9 +309,8 @@ context() {
   local user="$(whoami)"
   [[ "$user" != "$BULLETTRAIN_CONTEXT_DEFAULT_USER" || -n "$BULLETTRAIN_IS_SSH_CLIENT" ]] && echo -n "${user}@$BULLETTRAIN_CONTEXT_HOSTNAME"
 }
-prompt_context() {
-  [[ $BULLETTRAIN_CONTEXT_SHOW == false ]] && return
 
+prompt_context() {
   local _context="$(context)"
   [[ -n "$_context" ]] && prompt_segment $BULLETTRAIN_CONTEXT_BG $BULLETTRAIN_CONTEXT_FG "$_context"
 }
@@ -373,8 +334,6 @@ preexec() {
 }
 
 precmd() {
-  [[ $BULLETTRAIN_EXEC_TIME_SHOW == false ]] && return
-
   local stop=`date +%s`
   local start=${cmd_timestamp:-$stop}
   let BULLETTRAIN_last_exec_duration=$stop-$start
@@ -382,8 +341,6 @@ precmd() {
 }
 
 prompt_cmd_exec_time() {
-  [[ $BULLETTRAIN_EXEC_TIME_SHOW == false ]] && return
-
   [ $BULLETTRAIN_last_exec_duration -gt $BULLETTRAIN_EXEC_TIME_ELAPSED ] && prompt_segment $BULLETTRAIN_EXEC_TIME_BG $BULLETTRAIN_EXEC_TIME_FG "$(displaytime $BULLETTRAIN_last_exec_duration)"
 }
 
@@ -400,10 +357,6 @@ prompt_custom() {
 
 # Git
 prompt_git() {
-  if [[ $BULLETTRAIN_GIT_SHOW == false ]]; then
-    return
-  fi
-
   local ref dirty mode repo_path git_prompt
   repo_path=$(git rev-parse --git-dir 2>/dev/null)
 
@@ -424,10 +377,6 @@ prompt_git() {
 }
 
 prompt_hg() {
-  if [[ $BULLETTRAIN_HG_SHOW == false ]]; then
-    return
-  fi
-
   local rev status
   if $(hg id >/dev/null 2>&1); then
     if $(hg prompt >/dev/null 2>&1); then
@@ -464,10 +413,6 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  if [[ $BULLETTRAIN_DIR_SHOW == false ]]; then
-    return
-  fi
-
   local dir=''
   local _context="$(context)"
   [[ $BULLETTRAIN_DIR_CONTEXT_SHOW == true && -n "$_context" ]] && dir="${dir}${_context}:"
@@ -491,10 +436,6 @@ prompt_dir() {
 # RBENV: shows current ruby version active in the shell; also with non-global gemsets if any is active
 # CHRUBY: shows current ruby version active in the shell
 prompt_ruby() {
-  if [[ $BULLETTRAIN_RUBY_SHOW == false ]]; then
-    return
-  fi
-
   if command -v rvm-prompt > /dev/null 2>&1; then
     prompt_segment $BULLETTRAIN_RUBY_BG $BULLETTRAIN_RUBY_FG $BULLETTRAIN_RUBY_PREFIX" $(rvm-prompt i v g)"
   elif command -v chruby > /dev/null 2>&1; then
@@ -515,10 +456,6 @@ prompt_ruby() {
 # PERL
 # PLENV: shows current PERL version active in the shell
 prompt_perl() {
-  if [[ $BULLETTRAIN_PERL_SHOW == false ]]; then
-    return
-  fi
-
   if command -v plenv > /dev/null 2>&1; then
     prompt_segment $BULLETTRAIN_PERL_BG $BULLETTRAIN_PERL_FG $BULLETTRAIN_PERL_PREFIX" $(plenv version | sed -e 's/ (set.*$//')"
   fi
@@ -526,10 +463,6 @@ prompt_perl() {
 
 # Go
 prompt_go() {
-  if [[ $BULLETTRAIN_GO_SHOW == false ]]; then
-    return
-  fi
-
   setopt extended_glob
   if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
@@ -540,10 +473,6 @@ prompt_go() {
 
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
-  if [[ $BULLETTRAIN_VIRTUALENV_SHOW == false ]]; then
-    return
-  fi
-
   local virtualenv_path="$VIRTUAL_ENV"
   if [[ -n $virtualenv_path && -n $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
     prompt_segment $BULLETTRAIN_VIRTUALENV_BG $BULLETTRAIN_VIRTUALENV_FG $BULLETTRAIN_VIRTUALENV_PREFIX" $(basename $virtualenv_path)"
@@ -554,10 +483,6 @@ prompt_virtualenv() {
 
 # NVM: Node version manager
 prompt_nvm() {
-  if [[ $BULLETTRAIN_NVM_SHOW == false ]]; then
-    return
-  fi
-
   local nvm_prompt
   if type nvm >/dev/null 2>&1; then
     nvm_prompt=$(nvm current 2>/dev/null)
@@ -570,10 +495,6 @@ prompt_nvm() {
 }
 
 prompt_time() {
-  if [[ $BULLETTRAIN_TIME_SHOW == false ]]; then
-    return
-  fi
-
   if [[ $BULLETTRAIN_TIME_12HR == true ]]; then
     prompt_segment $BULLETTRAIN_TIME_BG $BULLETTRAIN_TIME_FG %D{%r}
   else
@@ -586,10 +507,6 @@ prompt_time() {
 # - am I root
 # - are there background jobs?
 prompt_status() {
-  if [[ $BULLETTRAIN_STATUS_SHOW == false ]]; then
-    return
-  fi
-
   local symbols
   symbols=()
   [[ $RETVAL -ne 0 && $BULLETTRAIN_STATUS_EXIT_SHOW != true ]] && symbols+="✘"


### PR DESCRIPTION
This commit removes all `_SHOW` variables for showing/hiding segments. Now `Hg/Mercurial` completely disappears  - should I also remove (now empty) variable table from README?

Two remaining *SHOWs* are:
* `BULLETTRAIN_STATUS_EXIT_SHOW` - we may consider changing this from **boolean** into **enum**, as described in #179.
* `BULLETTRAIN_DIR_CONTEXT_SHOW`

What about default `BULLETTRAIN_PROMPT_ORDER` variable? Should I change it to conform default `_SHOW`s? Or, as this is anyway quite invasive change, we can leave it by? 

Any suggestions are welcome :smile:  