### PR TITLE
Add support to remove particular elements from prompt in .zshrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ BULLETTRAIN_PROMPT_ORDER=(
   time
 )
 ```
+To remove segments use an array with the elements in any order:
+
+```bash
+BULLETTRAIN_PROMPT_REMOVE=(nvm time)
 
 NOTE: You do not need to specify *end* segment - it will be added automatically. With this you can also specify custom segments.
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -34,6 +34,12 @@ if [ ! -n "${BULLETTRAIN_PROMPT_ORDER+1}" ]; then
   )
 fi
 
+if [ -n "${BULLETTRAIN_PROMPT_REMOVE+1}" ]; then
+  for item in $BULLETTRAIN_PROMPT_REMOVE; do
+    BULLETTRAIN_PROMPT_ORDER=("${(@)BULLETTRAIN_PROMPT_ORDER:#$item}")
+  done
+fi
+
 # PROMPT
 if [ ! -n "${BULLETTRAIN_PROMPT_CHAR+1}" ]; then
   BULLETTRAIN_PROMPT_CHAR="\$"


### PR DESCRIPTION
If $ZSH is set outside the home dir (as in [Archlinux's AUR package](https://aur.archlinux.org/packages/bullet-train-oh-my-zsh-theme-git/) or to install once for multiple users) removing elements from the prompt requires root access. To avoid this I added a BULLETTRAIN_PROMPT_REMOVE option to remove several elements just editing the .zshrc in the home directory.