### PR TITLE
Make a field separator configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 |`BULLETTRAIN_PROMPT_ROOT`|`true`|Highlight if running as root
 |`BULLETTRAIN_PROMPT_SEPARATE_LINE`|`true`|Make the prompt span across two lines
 |`BULLETTRAIN_PROMPT_ADD_NEWLINE`|`true`|Adds a newline character before each prompt line
+|`BULLETTRAIN_PROMPT_SEGMENT_SEPARATOR` |``|Character to be show between prompt segments
 
 
 ### Status

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -286,6 +286,9 @@ if [ ! -n "${BULLETTRAIN_EXEC_TIME_FG+1}" ]; then
   BULLETTRAIN_EXEC_TIME_FG=black
 fi
 
+if [ ! -n "${BULLETTRAIN_PROMPT_SEGMENT_SEPARATOR}" ]; then
+  BULLETTRAIN_PROMPT_SEGMENT_SEPARATOR=''
+fi
 
 # ------------------------------------------------------------------------------
 # SEGMENT DRAWING
@@ -293,7 +296,6 @@ fi
 # ------------------------------------------------------------------------------
 
 CURRENT_BG='NONE'
-SEGMENT_SEPARATOR=''
 
 # Begin a segment
 # Takes three arguments, background, foreground and text. All of them can be omitted,
@@ -303,7 +305,7 @@ prompt_segment() {
   [[ -n $1 ]] && bg="%K{$1}" || bg="%k"
   [[ -n $2 ]] && fg="%F{$2}" || fg="%f"
   if [[ $CURRENT_BG != 'NONE' && $1 != $CURRENT_BG ]]; then
-    echo -n " %{$bg%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR%{$fg%} "
+    echo -n " %{$bg%F{$CURRENT_BG}%}$BULLETTRAIN_PROMPT_SEGMENT_SEPARATOR%{$fg%} "
   else
     echo -n "%{$bg%}%{$fg%} "
   fi
@@ -314,7 +316,7 @@ prompt_segment() {
 # End the prompt, closing any open segments
 prompt_end() {
   if [[ -n $CURRENT_BG ]]; then
-    echo -n " %{%k%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR"
+    echo -n " %{%k%F{$CURRENT_BG}%}$BULLETTRAIN_PROMPT_SEGMENT_SEPARATOR"
   else
     echo -n "%{%k%}"
   fi


### PR DESCRIPTION
Some Powerline fonts (for example https://github.com/ryanoasis/powerline-extra-symbols) provide extra symbols to use as field separators. This PR lets users to choose segment separator by setting BULLETTRAIN_PROMPT_SEGMENT_SEPARATOR in .zshrc.