### PR TITLE
Better discovery of .go files

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -533,10 +533,9 @@ prompt_perl() {
 
 # Go
 prompt_go() {
-  setopt extended_glob
-  if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
+  if [[ ! -z "$(find "." -maxdepth 1 -name "*.go"|head -n1)" || -d Godeps || -f glide.yaml ]]; then
     if command -v go > /dev/null 2>&1; then
-      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]+')"
+      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | awk '{print substr($3, 3)}')"
     fi
   fi
 }


### PR DESCRIPTION
Use `find` and search one level deep. The method for using `-f` was not working on Ubuntu 18.04 and I was unable to get it to work.

I am also using #280, because that's quite nice.