### PR TITLE
fix(kubernetes-context): added to default prompt order

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -29,6 +29,7 @@ if [ ! -n "${BULLETTRAIN_PROMPT_ORDER+1}" ]; then
     virtualenv
     nvm
     aws
+    kctx
     go
     rust
     elixir
@@ -558,7 +559,7 @@ prompt_kctx() {
   if command -v kubectl > /dev/null 2>&1; then
     if [[ -f $BULLETTRAIN_KCTX_KCONFIG ]]; then
       prompt_segment $BULLETTRAIN_KCTX_BG $BULLETTRAIN_KCTX_FG $BULLETTRAIN_KCTX_PREFIX" $(cat $BULLETTRAIN_KCTX_KCONFIG|grep current-context| awk '{print $2}')"
-    fi  
+    fi
   fi
 }
 


### PR DESCRIPTION
As requested here: https://github.com/caiogondim/bullet-train.zsh/pull/257#issuecomment-415733705

Added it just after the aws prompt which seemed like the proper place