### PR TITLE
Use `kubectl` to find current context

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,7 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 |`BULLETTRAIN_KCTX_BG`|`yellow`|Background color
 |`BULLETTRAIN_KCTX_FG`|`white`|Foreground color
 |`BULLETTRAIN_KCTX_PREFIX`|`⎈`|[Kubernetes](https://unicode-table.com/de/2388/) prefix of the segment
-|`BULLETTRAIN_KCTX_KCONFIG`|`<MUST_BE_SET>`|Location of kube config file (e.g. /Users/Hugo/.kube/config)
 
-`BULLETTRAIN_KCTX_KCONFIG` must be set, e.g. in .zshrc. There can be no default value and `~/` can not be reliably interpreted. The prompt will also do a sanity check whether `kubectl` is installed. If either condition fails, the prompt segment will not be drawn at all. 
 
 ### AWS Profile
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -552,14 +552,11 @@ prompt_rust() {
 
 # Kubernetes Context
 prompt_kctx() {
-  if [[ ! -n $BULLETTRAIN_KCTX_KCONFIG ]]; then
-    return
+  kctx="$(kubectl config current-context 2>/dev/null)"
+  if [ $? -eq 0 ]; then
+    prompt_segment $BULLETTRAIN_KCTX_BG $BULLETTRAIN_KCTX_FG $BULLETTRAIN_KCTX_PREFIX" ${kctx}"
   fi
-  if command -v kubectl > /dev/null 2>&1; then
-    if [[ -f $BULLETTRAIN_KCTX_KCONFIG ]]; then
-      prompt_segment $BULLETTRAIN_KCTX_BG $BULLETTRAIN_KCTX_FG $BULLETTRAIN_KCTX_PREFIX" $(cat $BULLETTRAIN_KCTX_KCONFIG|grep current-context| awk '{print $2}')"
-    fi  
-  fi
+  unset kctx
 }
 
 # Virtualenv: current working virtualenv


### PR DESCRIPTION
This makes setup easier: we no longer need the
`BULLETTRAIN_KCTX_KCONFIG` variable and more reliable since that
variable can be out of sync with reality (e.g. `export KUBECONFIG=...`)