### PR TITLE
Add option to disable NVM prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
+|`BULLETTRAIN_DISABLE_NVM`|none|Hide the NVM prompt
 |`BULLETTRAIN_NVM_BG`|`green`|Background color
 |`BULLETTRAIN_NVM_FG`|`white`|Foreground color
 |`BULLETTRAIN_NVM_PREFIX`|`"⬡ "`|Prefix of the segment

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -558,7 +558,7 @@ prompt_kctx() {
   if command -v kubectl > /dev/null 2>&1; then
     if [[ -f $BULLETTRAIN_KCTX_KCONFIG ]]; then
       prompt_segment $BULLETTRAIN_KCTX_BG $BULLETTRAIN_KCTX_FG $BULLETTRAIN_KCTX_PREFIX" $(cat $BULLETTRAIN_KCTX_KCONFIG|grep current-context| awk '{print $2}')"
-    fi  
+    fi
   fi
 }
 
@@ -574,6 +574,9 @@ prompt_virtualenv() {
 
 # NVM: Node version manager
 prompt_nvm() {
+  if [[ -n "$BULLETTRAIN_DISABLE_NVM" ]]; then
+    return
+  fi
   local nvm_prompt
   if type nvm >/dev/null 2>&1; then
     nvm_prompt=$(nvm current 2>/dev/null)


### PR DESCRIPTION
I don't use NVM and an option to disable it's prompt is very useful for me, so I don't have to alter the theme file.