### PR TITLE
Improve detection of Go projects

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -543,7 +543,7 @@ prompt_perl() {
 # Go
 prompt_go() {
   setopt extended_glob
-  if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
+  if [[ (-d Godeps || -f glide.yaml || -f *.go(#qN)) ]]; then
     if command -v go > /dev/null 2>&1; then
       prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]+')"
     fi

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -543,7 +543,7 @@ prompt_perl() {
 # Go
 prompt_go() {
   setopt extended_glob
-  if [[ (-d Godeps || -f glide.yaml || -f *.go(#qN)) ]]; then
+  if [[ (-f go.mod || -f Gopkg.toml || -d Godeps || -f glide.yaml || -f *.go(#qN)) ]]; then
     if command -v go > /dev/null 2>&1; then
       prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]+')"
     fi


### PR DESCRIPTION
By checking for the files used by the `go mod` and `dep` tools, this should noticeably improve the detection of Go projects.