### PR TITLE
Add terraform workspace prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ If `BULLETTRAIN_KCTX_KUBECTL=false` or `kubectl` is not installed, `BULLETTRAIN_
 
 The usage of `kubectl` allow the prompt to get the default namespace even if you are using multiple kube config files (e.g. KUBECONFIG=~/.kube/config:path-to-config1:path-to-config2)
 
-
 ### AWS Profile
 
 Displays which AWS (Amazon Web Services) credentials profile is currently set.
@@ -257,6 +256,14 @@ This environment var is used by aws-cli and other tools to use the right access 
 |`BULLETTRAIN_GIT_DIVERGED`|`" ⬍"`|Icon for diverged state from remote
 
 The git prompt can be disabled for a specific repository by setting a git config flag: `git config oh-my-zsh.hide-status 1`. This is useful to avoid performance issues for particularly huge repositories.
+
+### Terraform
+
+|Variable|Default|Meaning
+|--------|-------|-------|
+|`BULLETTRAIN_TERRAFORM_BG`|`magenta`|Background color
+|`BULLETTRAIN_TERRAFORM_FG`|`white`|Foreground color
+|`BULLETTRAIN_TERRAFORM_PREFIX`|`"♦"`|Prefix
 
 ### Screen
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -34,6 +34,7 @@ if [ ! -n "${BULLETTRAIN_PROMPT_ORDER+1}" ]; then
     elixir
     git
     hg
+    terraform
     cmd_exec_time
   )
 fi
@@ -330,6 +331,16 @@ if [ ! -n "${BULLETTRAIN_EXEC_TIME_FG+1}" ]; then
   BULLETTRAIN_EXEC_TIME_FG=black
 fi
 
+# TERRAFORM
+if [ ! -n "${BULLETTRAIN_TERRAFORM_BG+1}" ]; then
+    BULLETTRAIN_TERRAFORM_BG=magenta
+fi
+if [ ! -n "${BULLETTRAIN_TERRAFORM_FG+1}" ]; then
+    BULLETTRAIN_TERRAFORM_FG=white
+fi
+if [ ! -n "${BULLETTRAIN_TERRAFORM_PREFIX+1}" ]; then
+    BULLETTRAIN_TERRAFORM_PREFIX="♦"
+fi
 
 # ------------------------------------------------------------------------------
 # SEGMENT DRAWING
@@ -606,6 +617,13 @@ prompt_aws() {
   if [[ -n "$AWS_PROFILE" ]]; then
     prompt_segment $BULLETTRAIN_AWS_BG $BULLETTRAIN_AWS_FG $BULLETTRAIN_AWS_PREFIX$spaces$AWS_PROFILE
   fi
+}
+
+prompt_terraform() {
+    local workspace="$(tf_prompt_info || echo '')"
+    if [[ -n "$workspace" ]]; then
+        prompt_segment $BULLETTRAIN_TERRAFORM_BG $BULLETTRAIN_TERRAFORM_FG "$BULLETTRAIN_TERRAFORM_PREFIX $workspace"
+    fi
 }
 
 # SCREEN Session


### PR DESCRIPTION
Show the Terraform Workspace in the prompt, leveraging the `terraform` plugin from `oh-my-zsh`.

Closes #302 .

![Screenshot_20200323_141118](https://user-images.githubusercontent.com/3527534/77316524-3d175680-6d12-11ea-87cb-d36f2ade09b7.png)
