### PR TITLE
Fix nvm version display with Windows NVM

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -586,10 +586,19 @@ prompt_virtualenv() {
 
 # NVM: Node version manager
 prompt_nvm() {
+  local nvm_prompt_win
+  local nvm_prompt_win_lines
   local nvm_prompt
   if type nvm >/dev/null 2>&1; then
+    nvm_prompt_win=$(nvm version 2>/dev/null)
+    nvm_prompt_win_lines=$(echo "${nvm_prompt_win}" | wc -l)
     nvm_prompt=$(nvm current 2>/dev/null)
-    [[ "${nvm_prompt}x" == "x" || "${nvm_prompt}" == "system" ]] && return
+
+    if [[ "${nvm_prompt_win}x" != "x" && $nvm_prompt_win_lines -eq 1 ]]; then
+      nvm_prompt=${nvm_prompt_win}
+    elif [[ "${nvm_prompt}x" == "x" || "${nvm_prompt}" == "system" ]]; then
+      return
+    fi
   elif type node >/dev/null 2>&1; then
     nvm_prompt="$(node --version)"
   else

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -586,20 +586,13 @@ prompt_virtualenv() {
 
 # NVM: Node version manager
 prompt_nvm() {
-  local nvm_prompt_win
-  local nvm_prompt_win_lines
   local nvm_prompt
   if type nvm >/dev/null 2>&1; then
-    nvm_prompt_win=$(nvm version 2>/dev/null)
-    nvm_prompt_win_lines=$(echo "${nvm_prompt_win}" | wc -l)
     nvm_prompt=$(nvm current 2>/dev/null)
-
-    if [[ "${nvm_prompt_win}x" != "x" && $nvm_prompt_win_lines -eq 1 ]]; then
-      nvm_prompt=${nvm_prompt_win}
-    elif [[ "${nvm_prompt}x" == "x" || "${nvm_prompt}" == "system" ]]; then
-      return
-    fi
-  elif type node >/dev/null 2>&1; then
+    [[ "${nvm_prompt}x" == "x" || "${nvm_prompt}" == "system" ]] && return
+  fi
+  # Since `nvm current` is not available in windows-nvm, node should be tested separately
+  if type node >/dev/null 2>&1; then
     nvm_prompt="$(node --version)"
   else
     return


### PR DESCRIPTION
Since the windows nvm has no `nvm current` action. I fixed node version test for windows-nvm.

Calling of `nvm current` for windows NVM will get something like this:
![image](https://user-images.githubusercontent.com/3257783/92659456-facaeb80-f32a-11ea-98ed-d05531107380.png)
