### PR TITLE
Support for Guix environments and profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ simplicity, showing information only when it's relevant.
 
 It currently shows:
 - Current Python virtualenv; when using Pyenv and no active virtualenv shows the current Python version the shell uses
+- Current Guix Profile(s) or Environment(s)
 - Current Ruby version using chruby; version and gemset when on RVM or Rbenv
 - Current Node.js version, through NVM (if present) or Node.js
 - Current Perl version using plenv
@@ -153,6 +154,21 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 |`BULLETTRAIN_VIRTUALENV_BG`|`yellow`|Background color
 |`BULLETTRAIN_VIRTUALENV_FG`|`white`|Foreground color
 |`BULLETTRAIN_VIRTUALENV_PREFIX`|`🐍`|Prefix of the segment
+
+### Guix Profiles/Environments
+
+|Variable|Default|Meaning
+|--------|-------|-------|
+|`BULLETTRAIN_VIRTUALENV_BG`|`green`|Background color
+|`BULLETTRAIN_VIRTUALENV_FG`|`black`|Foreground color
+|`BULLETTRAIN_VIRTUALENV_PREFIX`|`🦬`|Prefix of the segment
+
+Note:
+- Profiles and environments can be stacked on top of each other, the order is tracked by the plugin and represented using "←".
+- Environments are represented with a 🌍 symbol + any switches provided.
+- Currently profiles must be initialized using the GUIX_PROFILE environment variable to be picked-up.
+- Environments with the --pure switch are not separately supported yet.
+
 
 ### node.js nvm
 
@@ -343,6 +359,7 @@ of the project:
   1	Nicholas
   1	Peter Nagy
   1	Sen Jiang
+  1	Phil Beadling
 ```
 
 ## Credits

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -27,6 +27,7 @@ if [ ! -n "${BULLETTRAIN_PROMPT_ORDER+1}" ]; then
     perl
     ruby
     virtualenv
+    guixenv
     nvm
     aws
     go
@@ -94,6 +95,17 @@ if [ ! -n "${BULLETTRAIN_VIRTUALENV_FG+1}" ]; then
 fi
 if [ ! -n "${BULLETTRAIN_VIRTUALENV_PREFIX+1}" ]; then
   BULLETTRAIN_VIRTUALENV_PREFIX=🐍
+fi
+
+# GUIXENV
+if [ ! -n "${BULLETTRAIN_GUIXENV_BG+1}" ]; then
+  BULLETTRAIN_GUIXENV_BG=green
+fi
+if [ ! -n "${BULLETTRAIN_GUIXENV_FG+1}" ]; then
+  BULLETTRAIN_GUIXENV_FG=black
+fi
+if [ ! -n "${BULLETTRAIN_GUIXENV_PREFIX+1}" ]; then
+  BULLETTRAIN_GUIXENV_PREFIX=🦬
 fi
 
 # NVM
@@ -582,6 +594,66 @@ prompt_virtualenv() {
       prompt_segment $BULLETTRAIN_VIRTUALENV_BG $BULLETTRAIN_VIRTUALENV_FG $BULLETTRAIN_VIRTUALENV_PREFIX" $(pyenv version | sed -e 's/ (set.*$//' | tr '\n' ' ' | sed 's/.$//')"
     fi
   fi
+}
+
+
+# Guix Environments and Profiles
+# --------
+# Explanation of mechanism:
+# https://unix.stackexchange.com/questions/638211/coproc-and-named-pipe-behaviour-under-command-substitution
+# https://unix.stackexchange.com/questions/486230/how-to-store-and-load-a-zsh-string-array-to-a-file
+
+# User-based temp storage for named pipes
+PIPE_STORE="${HOME}/.pipes-bullet-train"
+mkdir -p "${PIPE_STORE}"
+# Location of named pipe and clean-up
+# &! is just to hide job/pid
+# If guix is in ps it's a subprocess started by guix (guix environment)
+# - hence we already have a named pipe in the parent shell
+# Initialize the pipe with base profile (or empty)
+ps | grep -q guix ||
+    { export NAMEDP="${PIPE_STORE}/$$.bullet.tmp"
+      trap "rm -f \"${NAMEDP}\"" EXIT
+      rm -f "${NAMEDP}"
+      local init_profile=( "$(basename \"${GUIX_PROFILE}\")" )
+      mkfifo "${NAMEDP}" && typeset -p init_profile > "${NAMEDP}" &! }
+
+prompt_guixenv() {
+  local last_command=( ${(s: :)$(fc -ln | tail -1)} )
+  local candidate_addition=""
+  # Load the array saved to the pipe
+  source "${NAMEDP}"
+  
+  # Have we just exited a guix environment?
+  # Watch for the edge-case when the last command fails!
+  if [[ ! -n "${GUIX_ENVIRONMENT}" && "${last_command[1]}" == "guix" && "${last_command[2]}" == "environment" && ${RETVAL} -eq 0 ]]; then
+    local last_env_index=$profiles[(I)🌍*]
+    profiles=( "${profiles[@]:0:${last_env_index}-1}" )
+  fi
+
+  # Have we just entered a guix environment?
+  if [[ -n "${GUIX_ENVIRONMENT}" && "${last_command[1]}" == "guix" && "${last_command[2]}" == "environment" && ${RETVAL} -eq 0 ]]; then
+    # Guix Environment Prompt
+    candidate_addition="🌍 ${(j:,:)last_command[@]:2}"
+  # Otherwise just check the guix profile
+  elif [[ -n "${GUIX_PROFILE}" ]]; then
+    # Guix Profile Prompt
+    candidate_addition=$(basename ${GUIX_PROFILE})
+  fi
+  # We only add it if is unique in the current list
+  # This avoids repeating profiles either side of an environment if only testing the last element
+  [[ $profiles[(Ie)$candidate_addition] -eq 0 ]] && profiles+=( $candidate_addition )
+
+  # Do we have anything to display?
+  if [[ -n "$profiles" ]]; then
+     prompt_segment $BULLETTRAIN_GUIXENV_BG $BULLETTRAIN_GUIXENV_FG $BULLETTRAIN_GUIXENV_PREFIX" ${(j: ← :)profiles}"
+  fi
+  
+  # Close the file descriptor of stdout so the anonymous pipe from the command
+  # substitution created by $(build_prompt) at the bottom of this file is not
+  # held open waiting for writes from the subprocess (which cases a deadlock).
+  # Then send the profiles array to the named pipe for storage.
+  { exec >&-; typeset -p profiles > "${NAMEDP}" } &!
 }
 
 # NVM: Node version manager


### PR DESCRIPTION
Adding basic powerline support for Guix environments and profiles. It can handle stacking of profiles and environments, and can keep track of multiple profiles and/or environments.

Guix is the GNU Project's Operating System / Package Manager / Environment:
https://guix.gnu.org/

It's a little bit like Python pip and virtual environment setup on steroids (although this is a very limited analogy).