### PR TITLE
make the separator configurable

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -337,7 +337,7 @@ fi
 # ------------------------------------------------------------------------------
 
 CURRENT_BG='NONE'
-SEGMENT_SEPARATOR=''
+SEGMENT_SEPARATOR="${BULLETTRAIN_SEPARATOR:-}"
 
 # Begin a segment
 # Takes three arguments, background, foreground and text. All of them can be omitted,


### PR DESCRIPTION
Bullet Train already is *very* customizable, but I want a different look - one for which the default separator won't work. So, here's a patch to make it customizable.