### PR TITLE
README: Add quick install script for OMZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ In order to use the theme, you will first need:
 
 ### For oh-my-zsh users
 
+**Automatic Installation**
+
+Copy and paste the following into your terminal to automatically install Bullet Train:
+
+```bash
+[ -f ~/.zshrc ] && [ -d "$ZSH_CUSTOM/themes" ] && \
+curl -fsSL -o "$ZSH_CUSTOM/themes/bullet-train.zsh-theme" "http://raw.github.com/caiogondim/bullet-train-oh-my-zsh-theme/master/bullet-train.zsh-theme" && \
+sed -i $(if [[ "$OSTYPE" == "darwin"* ]]; then printf "''"; fi) 's/^ZSH_THEME=.*/ZSH_THEME="bullet-train"/' ~/.zshrc && \
+source ~/.zshrc
+```
+
+**Manual Installation**
+
 1. Download the theme [here](http://raw.github.com/caiogondim/bullet-train-oh-my-zsh-theme/master/bullet-train.zsh-theme)
 
 2. Put the file **bullet-train.zsh-theme** in **$ZSH_CUSTOM/themes/**


### PR DESCRIPTION
This pull request adds a script to README.md that allows for automatic installation of the Bullet Train theme. This script is copied from my dotfiles used to set up new Linux/macOS terminal environments.

This four line script does the following:

- Checks to make sure Oh My ZSH is installed (`~/.zshrc` and `$ZSH_CUSTOM/themes` exist)
- Silently downloads the latest version of the theme to `$ZSH_CUSTOM/themes/bullet-train.zsh-theme`
- Sets `ZSH_THEME` to the proper value in `~/.zshrc` (and changes `sed -i` to `sed -i ''` on macOS for [compatibility reasons][1])
- Sources `~/.zshrc` to activate the prompt

I have tested this script on macOS 13.2.1 (`zsh 5.8.1 (x86_64-apple-darwin22.0)`) and Ubuntu 22.04 (`zsh 5.8 (x86_64-ubuntu-linux-gnu)`).


[1]: https://stackoverflow.com/a/7573438