### PR TITLE
Fix: Check for presence of go files

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -543,7 +543,9 @@ prompt_perl() {
 # Go
 prompt_go() {
   setopt extended_glob
-  if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
+  go_files=( *.go(#qN) )
+
+  if [[ ($#go_files -gt 0 || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
       prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]+')"
     fi


### PR DESCRIPTION
Previously, the script only checked for a single .go file using the -f *.go(#qN) condition, resulting in a false negative when multiple .go files were present. This has been fixed by using an array to capture all matching .go files and checking the length of the array.